### PR TITLE
Fixing Shallow renderer deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mocha": "^3.0.2",
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.0",
+    "react-test-renderer": "^15.5.4",
     "rollup": "^0.34.9",
     "rollup-plugin-buble": "^0.13.0",
     "rollup-plugin-commonjs": "^3.3.1",


### PR DESCRIPTION
This PR adds ```react-test-renderer``` dev dependency to fix warning/deprecation messages seen when running the tests.